### PR TITLE
feat(cluster): add in-memory config generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2025-08-31
+
+### Fixed
+- `ClusterBuilder::generateInMemory()` no longer delegates to disk generation; now builds YAML purely in memory.
+
+### Added
+- `TalosCluster::genTalosconfig(string $cluster, string $endpoint, array $flags = [])` to generate and return a `talosconfig` string using a temporary `talosctl gen config` run (no persistence).
+- `ClusterBuilder::talosconfigInMemory(array $flags = [])` convenience wrapper for fetching an in‑memory `talosconfig` for the builder’s cluster/endpoint.
+- `ClusterBuilder::generateTo(string $dir)` to explicitly generate configs to a target directory.
+
+### Changed
+- `ClusterBuilder` constructor `outDir` parameter is now optional (`?string`); when omitted, `generate()` uses a temporary directory under the system temp path.
+- README updated to recommend in-memory generation + `GeneratedConfigs::writeTo()` and to document `generateTo()`.
+
 ## [1.0.0] - YYYY-MM-DD
 
 Initial stable release.
 
-- Fluent builder API for Talos machine configuration
-- Secrets generation + injection (TalosSecrets; TalosCluster::genSecrets, ClusterBuilder::secrets)
-- YAML sequence normalization to avoid `{}` where lists are expected
-- Integration validation with `talosctl validate` (required), CI matrix for Talos current + prior
-- 100 0.000000e+00st coverage, PHPStan clean, Pint clean
+### Added
+- Fluent builder API for Talos machine configuration (networking, control plane, etcd, install helpers).
+- Secrets workflow: `TalosCluster::genSecrets()`, `TalosSecrets` (serialize/deserialize), `ClusterBuilder::secrets(...)` injection.
+- YAML patching helpers: `set()`, `patchBoth()`, `patchFile()` with documented precedence.
+- Integration validation with `talosctl validate`; CI matrix for Talos current + prior minor.
+- Laravel integration: `TalosFactory`, service provider, facade.
+
+### Quality
+- 100% test coverage, PHPStan clean, Pint formatted.

--- a/src/Builders/ClusterBuilder.php
+++ b/src/Builders/ClusterBuilder.php
@@ -461,7 +461,7 @@ final class ClusterBuilder
 
     public function generate(): string
     {
-        $dir = $this->outDir ?? rtrim(sys_get_temp_dir(), '/').'/talos-gen-'.uniqid();
+        $dir = $this->outDir ?? mb_rtrim(sys_get_temp_dir(), '/').'/talos-gen-'.uniqid();
 
         return $this->generateTo($dir);
     }
@@ -516,7 +516,8 @@ final class ClusterBuilder
 
     /** Convenience: generate a talosconfig string for this builder's
      *  cluster/endpoint using a temporary gen-config run (no persistence).
-     *  @param  array<int|string, string|bool>  $flags
+     *
+     * @param  array<int|string, string|bool>  $flags
      */
     public function talosconfigInMemory(array $flags = []): string
     {

--- a/src/TalosCluster.php
+++ b/src/TalosCluster.php
@@ -210,12 +210,14 @@ final class TalosCluster
     }
 
     /** Generate a talosconfig and return its contents as a string.
-     *  Uses a temporary directory; no persistent files are left behind.
-     *  @param  array<int|string, string|bool>  $flags
+     *  Uses a temporary directory by default; pass $outDir to control the path.
+     *  No persistent files are left behind.
+     *
+     * @param  array<int|string, string|bool>  $flags
      */
-    public function genTalosconfig(string $cluster, string $endpoint, array $flags = []): string
+    public function genTalosconfig(string $cluster, string $endpoint, array $flags = [], ?string $outDir = null): string
     {
-        $tmp = rtrim(sys_get_temp_dir(), '/').'/talos-tmp-'.uniqid();
+        $tmp = $outDir ?: (mb_rtrim(sys_get_temp_dir(), '/').'/talos-tmp-'.uniqid());
         @mkdir($tmp, 0775, true);
 
         // Reuse genConfig to invoke talosctl with any flags provided.

--- a/src/TalosCluster.php
+++ b/src/TalosCluster.php
@@ -209,6 +209,36 @@ final class TalosCluster
         return TalosSecrets::fromArray($data);
     }
 
+    /** Generate a talosconfig and return its contents as a string.
+     *  Uses a temporary directory; no persistent files are left behind.
+     *  @param  array<int|string, string|bool>  $flags
+     */
+    public function genTalosconfig(string $cluster, string $endpoint, array $flags = []): string
+    {
+        $tmp = rtrim(sys_get_temp_dir(), '/').'/talos-tmp-'.uniqid();
+        @mkdir($tmp, 0775, true);
+
+        // Reuse genConfig to invoke talosctl with any flags provided.
+        $dir = $this->genConfig($cluster, $endpoint, $tmp, $flags);
+        $path = $dir.'/talosconfig';
+
+        $content = is_file($path) ? (string) file_get_contents($path) : '';
+
+        // Best-effort cleanup
+        if (is_file($path)) {
+            @unlink($path);
+        }
+        // Remove other files if present
+        foreach (['controlplane.yaml', 'worker.yaml'] as $f) {
+            if (is_file($dir.'/'.$f)) {
+                @unlink($dir.'/'.$f);
+            }
+        }
+        @rmdir($dir);
+
+        return $content;
+    }
+
     /** @param array<int|string, string|bool> $flags */
     public function genConfigWithSecrets(string $cluster, string $endpoint, string $outputDir, TalosSecrets $secrets, array $flags = []): string
     {

--- a/tests/Fakes/ProcessRunnerWritingFake.php
+++ b/tests/Fakes/ProcessRunnerWritingFake.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fakes;
+
+use ArioLabs\Talos\Support\Runner;
+use Closure;
+
+final class ProcessRunnerWritingFake implements Runner
+{
+    public array $calls = [];
+
+    public function __construct(
+        private string $talosconfigContent = "kind: talosconfig\n",
+        private string $cpContent = "controlplane: true\n",
+        private string $wkContent = "worker: true\n",
+    ) {}
+
+    public function run(array $args, ?Closure $onChunk = null): array
+    {
+        $this->calls[] = $args;
+        // Find output directory in args (after --output)
+        $outIndex = array_search('--output', $args, true);
+        if ($outIndex !== false && isset($args[$outIndex + 1])) {
+            $dir = (string) $args[$outIndex + 1];
+            @mkdir($dir, 0775, true);
+            file_put_contents($dir.'/talosconfig', $this->talosconfigContent);
+            file_put_contents($dir.'/controlplane.yaml', $this->cpContent);
+            file_put_contents($dir.'/worker.yaml', $this->wkContent);
+        }
+
+        return [0, '', ''];
+    }
+}

--- a/tests/Feature/InMemoryPatchFileFeatureTest.php
+++ b/tests/Feature/InMemoryPatchFileFeatureTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use ArioLabs\Talos\Builders\ClusterBuilder;
+use ArioLabs\Talos\TalosCluster;
+use Symfony\Component\Yaml\Yaml;
+use Tests\Fakes\ProcessRunnerFake;
+
+it('applies per-file patches in generateInMemory() and normalizes sequences', function (): void {
+    $runner = new ProcessRunnerFake();
+    $talos = new TalosCluster($runner);
+
+    $b = new ClusterBuilder($talos, 'demo', '10.0.0.1');
+
+    // Add an empty sequence to exercise normalization + nested merge on both CP/WK
+    $b->set('cluster.apiServer.certSANs', []);
+
+    // Per-file patches with nested structures to hit recursive deepMerge
+    $b->patchFile('controlplane.yaml', [
+        'cluster' => [
+            'network' => [
+                'dnsDomain' => 'cluster.local',
+            ],
+        ],
+    ]);
+    $b->patchFile('worker.yaml', [
+        'machine' => [
+            'network' => [
+                'nameservers' => ['1.1.1.1'],
+            ],
+        ],
+    ]);
+
+    $configs = $b->generateInMemory();
+
+    $cp = Yaml::parse($configs->controlplane()) ?: [];
+    $wk = Yaml::parse($configs->worker()) ?: [];
+
+    expect($cp['cluster']['network']['dnsDomain'] ?? null)->toBe('cluster.local');
+    expect($wk['machine']['network']['nameservers'] ?? [])->toBe(['1.1.1.1']);
+
+    // certSANs was an empty sequence; it should be omitted after normalization
+    expect(isset($cp['cluster']['apiServer']['certSANs']))->toBeFalse();
+});

--- a/tests/Feature/TalosconfigInMemoryFromBuilderTest.php
+++ b/tests/Feature/TalosconfigInMemoryFromBuilderTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use ArioLabs\Talos\Builders\ClusterBuilder;
+use ArioLabs\Talos\TalosCluster;
+use Tests\Fakes\ProcessRunnerWritingFake;
+
+it('fetches talosconfig via builder talosconfigInMemory()', function (): void {
+    $runner = new ProcessRunnerWritingFake("kind: talosconfig\n");
+    $talos = new TalosCluster($runner);
+
+    $b = new ClusterBuilder($talos, 'demo', 'https://10.0.0.1:6443');
+    $cfg = $b->talosconfigInMemory();
+
+    expect($cfg)->toContain('kind: talosconfig');
+});

--- a/tests/TalosconfigGenerationTest.php
+++ b/tests/TalosconfigGenerationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use ArioLabs\Talos\TalosCluster;
+use Tests\Fakes\ProcessRunnerWritingFake;
+
+it('generates talosconfig in memory and cleans up temp files', function (): void {
+    $runner = new ProcessRunnerWritingFake(talosconfigContent: "kind: talosconfig\nclusters: []\n");
+    $talos = new TalosCluster($runner);
+
+    $dir = sys_get_temp_dir().'/talos-tmp-test-'.uniqid();
+    // Ensure directory does not exist yet
+    @rmdir($dir);
+
+    $content = $talos->genTalosconfig('demo', 'https://10.0.0.1:6443', outDir: $dir);
+
+    expect($content)->toContain('kind: talosconfig');
+    // Files should be removed by genTalosconfig
+    expect(is_file($dir.'/talosconfig'))->toBeFalse();
+    expect(is_file($dir.'/controlplane.yaml'))->toBeFalse();
+    expect(is_file($dir.'/worker.yaml'))->toBeFalse();
+    // Best-effort rmdir — directory may or may not be removed depending on FS; assert no files
+});


### PR DESCRIPTION
Add methods to generate Talos configurations in memory without disk persistence. Update ClusterBuilder to support optional outDir and introduce generateTo for explicit directory output. Enhance TalosCluster with genTalosconfig for in-memory talosconfig generation. Update documentation to reflect these changes.