### PR TITLE
feat(talosconfig): enhance secrets handling and flag overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.3] - 2025-08-31
+
+### Fixed
+- In-memory talosconfig generation now derives from provided `TalosSecrets` when available, ensuring the generated `talosconfig` CA/client certs match the cluster and avoiding "tls: unknown certificate authority" errors with `talosctl`.
+- `ClusterBuilder::talosconfigInMemory()` now propagates builder flags and uses the secrets-aware path automatically when `secrets(...)` have been set on the builder.
+
+### Added
+- `TalosCluster::genTalosconfigWithSecrets()` public helper for generating a `talosconfig` using a temporary `--with-secrets` flow.
+
+### Tests
+- Added tests covering secrets-aware talosconfig generation and flag overrides.
+
+### Notes
+- No breaking API changes. Existing builder usage remains valid; behavior improves under the hood when secrets are provided.
+
 ## [1.1.2] - 2025-08-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ $out = sys_get_temp_dir().'/talos-out-'.uniqid();
 $configs->writeTo($out);
 
 // Also get an in-memory talosconfig (not persisted; uses a temp dir under the hood)
+// If you've set secrets($secrets) on the builder, this talosconfig is derived from those
+// secrets so its CA/client certs match the cluster.
 $talosconfig = $builder->talosconfigInMemory();
 ```
 

--- a/src/Builders/ClusterBuilder.php
+++ b/src/Builders/ClusterBuilder.php
@@ -547,7 +547,17 @@ final class ClusterBuilder
      */
     public function talosconfigInMemory(array $flags = []): string
     {
-        return $this->talos->genTalosconfig($this->cluster, $this->endpoint, $flags);
+        // Merge builder flags with per-call flags (per-call overrides by key)
+        $mergedFlags = $this->flags;
+        foreach ($flags as $k => $v) {
+            $mergedFlags[$k] = $v;
+        }
+
+        if ($this->secrets instanceof \ArioLabs\Talos\TalosSecrets) {
+            return $this->talos->genTalosconfigWithSecrets($this->cluster, $this->endpoint, $this->secrets, $mergedFlags);
+        }
+
+        return $this->talos->genTalosconfig($this->cluster, $this->endpoint, $mergedFlags);
     }
 
     /** @param  array<int|string, mixed>  $patch */

--- a/src/TalosCluster.php
+++ b/src/TalosCluster.php
@@ -241,6 +241,36 @@ final class TalosCluster
         return $content;
     }
 
+    /** Same as genTalosconfig(), but ensures the generated talosconfig is derived
+     *  from the provided secrets so its CA/client certs match an existing cluster.
+     *
+     * @param  array<int|string, string|bool>  $flags
+     */
+    public function genTalosconfigWithSecrets(string $cluster, string $endpoint, TalosSecrets $secrets, array $flags = [], ?string $outDir = null): string
+    {
+        $tmp = $outDir !== null && $outDir !== '' && $outDir !== '0' ? $outDir : (mb_rtrim(sys_get_temp_dir(), '/').'/talos-tmp-'.uniqid());
+        @mkdir($tmp, 0775, true);
+
+        // Generate configs using supplied secrets so CA/client material is consistent.
+        $dir = $this->genConfigWithSecrets($cluster, $endpoint, $tmp, $secrets, $flags);
+        $path = $dir.'/talosconfig';
+
+        $content = is_file($path) ? (string) file_get_contents($path) : '';
+
+        // Best-effort cleanup
+        if (is_file($path)) {
+            @unlink($path);
+        }
+        foreach (['controlplane.yaml', 'worker.yaml'] as $f) {
+            if (is_file($dir.'/'.$f)) {
+                @unlink($dir.'/'.$f);
+            }
+        }
+        @rmdir($dir);
+
+        return $content;
+    }
+
     /** @param array<int|string, string|bool> $flags */
     public function genConfigWithSecrets(string $cluster, string $endpoint, string $outputDir, TalosSecrets $secrets, array $flags = []): string
     {

--- a/tests/Feature/BuilderTalosconfigFlagsOverrideTest.php
+++ b/tests/Feature/BuilderTalosconfigFlagsOverrideTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use ArioLabs\Talos\Builders\ClusterBuilder;
+use ArioLabs\Talos\TalosCluster;
+use Tests\Fakes\ProcessRunnerWritingFake;
+
+it('applies per-call flags override when generating talosconfig in memory', function (): void {
+    $runner = new ProcessRunnerWritingFake("kind: talosconfig\n");
+    $talos = new TalosCluster($runner);
+
+    $b = new ClusterBuilder($talos, 'demo', 'https://10.0.0.1:6443');
+    // Set a builder-level flag
+    $b->additionalSans(['initial.local']);
+
+    // Per-call flag should override the builder flag
+    $cfg = $b->talosconfigInMemory(['--additional-sans' => 'override.local']);
+    expect($cfg)->toContain('kind: talosconfig');
+
+    $args = $runner->calls[0] ?? [];
+    $hasOverride = false;
+    foreach ($args as $arg) {
+        if (is_string($arg) && $arg === '--additional-sans=override.local') {
+            $hasOverride = true;
+            break;
+        }
+    }
+    expect($hasOverride)->toBeTrue();
+});

--- a/tests/Feature/TalosconfigWithSecretsInMemoryFromBuilderTest.php
+++ b/tests/Feature/TalosconfigWithSecretsInMemoryFromBuilderTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use ArioLabs\Talos\Builders\ClusterBuilder;
+use ArioLabs\Talos\TalosCluster;
+use ArioLabs\Talos\TalosSecrets;
+use Tests\Fakes\ProcessRunnerWritingFake;
+
+it('fetches talosconfig via builder talosconfigInMemory() when secrets are set', function (): void {
+    $runner = new ProcessRunnerWritingFake("kind: talosconfig\n");
+    $talos = new TalosCluster($runner);
+
+    $secrets = TalosSecrets::fromArray(['cluster' => ['id' => 'xyz']]);
+
+    $b = new ClusterBuilder($talos, 'demo', 'https://10.0.0.1:6443');
+    $cfg = $b->secrets($secrets)->talosconfigInMemory();
+
+    expect($cfg)->toContain('kind: talosconfig');
+});

--- a/tests/TalosconfigWithSecretsGenerationTest.php
+++ b/tests/TalosconfigWithSecretsGenerationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use ArioLabs\Talos\TalosCluster;
+use ArioLabs\Talos\TalosSecrets;
+use Tests\Fakes\ProcessRunnerWritingFake;
+
+it('generates talosconfig with secrets and cleans up temp files', function (): void {
+    $runner = new ProcessRunnerWritingFake(talosconfigContent: "kind: talosconfig\nclusters: []\n");
+    $talos = new TalosCluster($runner);
+
+    $dir = sys_get_temp_dir().'/talos-tmp-test-ws-'.uniqid();
+    @rmdir($dir);
+
+    $secrets = TalosSecrets::fromArray(['cluster' => ['id' => 'abc']]);
+
+    $content = $talos->genTalosconfigWithSecrets('demo', 'https://10.0.0.1:6443', $secrets, outDir: $dir);
+
+    expect($content)->toContain('kind: talosconfig');
+    // Files should be removed by genTalosconfigWithSecrets
+    expect(is_file($dir.'/talosconfig'))->toBeFalse();
+    expect(is_file($dir.'/controlplane.yaml'))->toBeFalse();
+    expect(is_file($dir.'/worker.yaml'))->toBeFalse();
+
+    // It should have invoked talosctl with --with-secrets pointing to a temp file
+    $withSecretsPath = null;
+    foreach ($runner->calls as $call) {
+        foreach ($call as $arg) {
+            if (is_string($arg) && str_starts_with($arg, '--with-secrets=')) {
+                $withSecretsPath = (string) mb_substr($arg, mb_strlen('--with-secrets='));
+                break 2;
+            }
+        }
+    }
+    expect($withSecretsPath)->not()->toBeNull();
+    // Temp secrets file should be cleaned up by finally block
+    expect(is_file((string) $withSecretsPath))->toBeFalse();
+});


### PR DESCRIPTION
Improve in-memory talosconfig generation by deriving from provided TalosSecrets, ensuring CA/client certs match the cluster. Add public helper for generating talosconfig with secrets. Update tests to cover new functionality and flag overrides. No breaking API changes; existing usage remains valid.